### PR TITLE
Path independent database

### DIFF
--- a/utils/database.php
+++ b/utils/database.php
@@ -4,7 +4,11 @@ public $connection;
 public $connected = false;
   public function connect($dbname){
     //$ts_pw = posix_getpwuid(posix_getuid());
-    $ts_mycnf = parse_ini_file(getenv("DOCUMENT_ROOT") . "/../replica.my.cnf");
+    $prefix = getenv("DOCUMENT_ROOT") . "/..";
+    if (getenv("DOCUMENT_ROOT") === false) {
+        $prefix = getenv("HOME");
+    }
+    $ts_mycnf = parse_ini_file($prefix. "/replica.my.cnf");
     try {
       if ($dbname == 'meta')
       {

--- a/utils/database.php
+++ b/utils/database.php
@@ -4,7 +4,7 @@ public $connection;
 public $connected = false;
   public function connect($dbname){
     //$ts_pw = posix_getpwuid(posix_getuid());
-    $ts_mycnf = parse_ini_file("../replica.my.cnf");
+    $ts_mycnf = parse_ini_file(getenv("DOCUMENT_ROOT") . "/../replica.my.cnf");
     try {
       if ($dbname == 'meta')
       {


### PR DESCRIPTION
If someone (like me) ran this under urbanecm-test-1.toolforge.org/ptools, it would fail to access the database. Let's switch to environment varialbes instead, which should work always.