### PR TITLE
uploadersincat: Apply noHTML() when outputting category title, not when accepting it

### DIFF
--- a/uploadersincat.php
+++ b/uploadersincat.php
@@ -10,7 +10,7 @@ $h1='Commons Uploaders in cat';
 include('utils/header.php');
 
 if (!empty($_GET)) {
-$category=noHTML($_GET['category']);
+$category=$_GET['category'];
 }else{
 $category = '';
 }
@@ -20,7 +20,7 @@ $category = '';
 <fieldset><legend>Find uploaders in cat</legend>
 <form method="get" action="uploadersincat.php" id="mw-sulinfo-form1">
 <table border="0" id="mw-movepage-table"> 
-<tr><td class='mw-label'><label for="category">Category :</label></td><td class='mw-input'><input id="category" name="category" type="text" value="<?php echo $category; ?>"/></td>
+<tr><td class='mw-label'><label for="category">Category :</label></td><td class='mw-input'><input id="category" name="category" type="text" value="<?php echo noHTML($category); ?>"/></td>
 <tr><td>&#160;</td><td class='mw-submit'><input type="submit" value="Go !" /></td></tr>
 </table>
 </form></fieldset>


### PR DESCRIPTION
It is perfectly valid to have a category named `Foo:bar:baz`,
however, this tool would pass it to category class as `Foo&colon;bar&colon;baz`,
which is also perfectly valid, but not what the user intended to input. It doesn't hurt
to pass valid HTML to the database - PDO's escpaing should handle that well and not let
any characters capable to cause SQL injection to reach the database.

To prevent attackers from naming category `<script>alert('foo');</script>`,
let's escape the category name when we output it. At that point, outputing
`&colon;` instead of colons doesn't hurt anything.

Fixes #5.